### PR TITLE
fix path matching for wildcard query params

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -176,6 +176,19 @@ describe("pathToRegex", () => {
     });
   });
 
+  it("should match route with wildcard query parameters", () => {
+    expect(
+      new PathRegExp("/foo?*", false).match("/foo?bar=123&bob=abc"),
+    ).toEqual({
+      absolute: true,
+      matched: "/foo?bar=123&bob=abc",
+      params: {
+        "*": "bar=123&bob=abc",
+      },
+      path: "/foo?*",
+    });
+  });
+
   it("should match route with query parameters", () => {
     expect(new PathRegExp("/foo?bar=:id", true).match("/foo?bar=123")).toEqual({
       absolute: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,10 @@ export function parse(input: string, exact = false) {
     if (char === CHARS.COLON) {
       param = i + 1;
     } else if (param !== -1) {
-      const isDelimiter = char === CHARS.SLASH || char === CHARS.AMPERSAND;
+      const isDelimiter =
+        char === CHARS.SLASH ||
+        char === CHARS.AMPERSAND ||
+        char === CHARS.QUESTION_MARK;
       const isEnd = i === len - 1;
       if (isDelimiter || isEnd) {
         params.push(input.slice(param, isEnd && !isDelimiter ? len : i));
@@ -66,7 +69,7 @@ export function parse(input: string, exact = false) {
 function normalize(url: string) {
   // Normalize url
   return url.length > 1 &&
-    (url.charCodeAt(url.length - 1) === CHARS.SLASH || url.indexOf("=") > -1)
+    (url.charCodeAt(url.length - 1) === CHARS.SLASH || url.indexOf("?") > -1)
     ? url
     : url + "/";
 }


### PR DESCRIPTION
The current version is not working with path definitions that have wildcard query parameters like `/foo?*`
We are still using this library in our project, so it would be great if this fix will become part of the code and we are able to pull the new fixed version from NPM soon.

Have a great weekend!
Greetz Erik